### PR TITLE
Refactor OSRM model status UI and remove obstacles logic

### DIFF
--- a/osrm-management-system/src/services/build-tracker.service.ts
+++ b/osrm-management-system/src/services/build-tracker.service.ts
@@ -94,8 +94,8 @@ export class BuildTrackerService {
    */
   async markFailed(buildId: string, errorMessage: string): Promise<void> {
     // Truncate error message to prevent database field overflow
-    // MySQL VARCHAR(255) is common, so we limit to 250 chars for safety (including '...')
-    const MAX_ERROR_LENGTH = 250;
+    // Reduce to 200 chars to be safe (including '...')
+    const MAX_ERROR_LENGTH = 200;
     const truncatedError = errorMessage.length > MAX_ERROR_LENGTH 
       ? errorMessage.substring(0, MAX_ERROR_LENGTH - 3) + '...' 
       : errorMessage;


### PR DESCRIPTION
Split OSRM model status into separate sections for bicycle and car models in the SystemManagementView UI, improving clarity and management actions. In generate.service.ts, remove all references to the Obstacles module and related logic, as it is not available in the OSRM backend. Also, reduce the max error message length in build-tracker.service.ts to 200 characters for safer database storage.